### PR TITLE
Rewrite README.md and --help message; Adjust the measurement function

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ make
 ## Execution
 The circuit format being simulated is `OpenQASM` used by IBM's [Qiskit](https://github.com/Qiskit/qiskit), and the gate set supported in this simulator now contains Pauli-X (x), Pauli-Y (y), Pauli-Z (z), Hadamard (h), Phase and its inverse (s and sdg), π/8 and its inverse (t and tdg), Rotation-X with phase π/2 (rx(pi/2)), Rotation-Y with phase π/2 (ry(pi/2)), Controlled-NOT (cx), Controlled-Z (cz), Toffoli (ccx and mcx), SWAP (swap), and Fredkin (cswap). One can find some example benchmarks in [examples](https://github.com/NTU-ALComLab/SliQSim/tree/master/examples) folder. 
 
-For simulation types, we provide both weak and strong simulation options. The help message states the details:
+For simulation types, we provide both "sampling" and "all_amplitude" simulation options. The help message states the details:
 
 ```commandline
 $ ./SliQSim --help
@@ -26,29 +26,23 @@ Options:
 --help                produce help message
 --sim_qasm arg        simulate qasm file string
 --seed [=arg(=1)]     seed for random number generator
---print_info          print simulation statistics such as runtime,
-                      memory, etc.
+--print_info          print simulation statistics such as runtime, memory, etc.
 --type arg (=0)       the simulation type being executed.
-                      0: weak simulation (default option) where the sampled 
-                      outcome(s) will be provided after the simulation. The
-                      number of outcomes being sampled can be set by argument
-                      "shots" (1 by default).
-                      1: strong simulation where the resulting state vector
-                      will be shown after the simulation. Note that this
-                      option should be avoided if the number of qubits is
-                      large since it will result in extremely long runtime.
---shots arg (=1)      the number of outcomes being sampled, this argument is
-                      only used when the simulation type is set to "weak".
+                      0: sampling mode (default option), where the sampled outcomes will be provided. 
+                      1: all_amplitude mode, where the final state vector will be shown. 
+--shots arg (=1)      the number of outcomes being sampled in "sampling mode" .
 --r arg (=32)         integer bit size.
 --reorder arg (=1)    allow variable reordering or not.
                       0: disable reordering.
                       1: enable reordering (default option).
 --alloc arg (=1)      allocate new BDDs when overflow is detected.
-                      0: do not allocate new BDDs. This may lead to numerical
-                      errors.
+                      0: do not allocate new BDDs. This may lead to numerical errors.
                       1: allocate new BDDs (default option).
+
 ```
-For example, simulating [example/bell_state_measure.qasm](https://github.com/NTU-ALComLab/SliQSim/blob/master/examples/bell_state_measure.qasm), which is a 2-qubit bell state circuit with measurement gates at the end, with the weak simulation option can be executed by
+To use the sampling mode (default), it is required to have measurement operations included in the qasm file. Conversely, in all_amplitude mode, measurement operations are generally omitted, but if they are present in the qasm file, the final state vector will collapse based on the measurement result. It is important to note that all_amplitude mode is not recommended for simulations involving a large number of qubits, as it could result in a significantly long runtime.
+
+For example, simulating [example/bell_state_measure.qasm](https://github.com/NTU-ALComLab/SliQSim/blob/master/examples/bell_state_measure.qasm), which is a 2-qubit bell state circuit with measurement gates at the end, with the sampling mode simulation option can be executed by
 ```commandline
 ./SliQSim --sim_qasm examples/bell_state_measure.qasm --type 0 --shots 1024
 ```
@@ -68,14 +62,14 @@ If option `--print_info` is used, simulation statistics such as runtime and memo
   Accuracy loss: 2.22045e-16
 ```
 
-To demostrate the strong simulation, we use [example/bell_state.qasm](https://github.com/NTU-ALComLab/SliQSim/blob/master/examples/bell_state.qasm), which is the same circuit as in the weak simulation example except that the measurement gates are removed:
+To demostrate the all_amplitude mode simulation, we use [example/bell_state.qasm](https://github.com/NTU-ALComLab/SliQSim/blob/master/examples/bell_state.qasm), which is the same circuit as in the sampling mode simulation example except that the measurement gates are removed:
 ```commandline
 ./SliQSim --sim_qasm examples/bell_state.qasm --type 1
 ```
 
 This will show the resulting state vector:
 ```commandline
-{ "counts": { "00": 1 }, "statevector": ["0.707107", "0", "0", "0.707107"] }
+{"statevector": ["0.707107", "0", "0", "0.707107"] }
 ```
 
 One may also execute our simulator as a backend option of Qiskit through [SliQSim Qiskit Interface](https://github.com/NTU-ALComLab/SliQSim-Qiskit-Interface).

--- a/src/Simulator.h
+++ b/src/Simulator.h
@@ -26,12 +26,12 @@ public:
     // constructor and destructor
     Simulator(int type, int nshots, int seed, int bitSize, bool reorder, bool alloc) :
     n(0), r(bitSize), w(4), k(0), inc(3), shift(0), error(0),
-    normalize_factor(1), gatecount(0), NodeCount(0), isMeasure(0), measured_qubits(0), shots(nshots), isReorder(reorder), isAlloc(alloc)
+    normalize_factor(1), gatecount(0), NodeCount(0), isMeasure(0), shots(nshots), isReorder(reorder), isAlloc(alloc)
     , sim_type(type), statevector("null"), gen(std::default_random_engine(seed)){
     }
     Simulator(int nshots, int seed, int bitSize, bool reorder, bool alloc) :
     n(0), r(bitSize), w(4), k(0), inc(3), shift(0), error(0),
-    normalize_factor(1), gatecount(0), NodeCount(0), isMeasure(0), measured_qubits(0), shots(nshots), isReorder(reorder), isAlloc(alloc)
+    normalize_factor(1), gatecount(0), NodeCount(0), isMeasure(0), shots(nshots), isReorder(reorder), isAlloc(alloc)
     , sim_type(0), statevector("null"), gen(std::default_random_engine(seed)){
     }
     ~Simulator()  {
@@ -82,8 +82,8 @@ private:
     bool isMeasure;
     bool isReorder;
     bool isAlloc;
-    std::vector<int> measured_qubits; // i-th element is the i-th qubit measured
-    int *measured_qubits_to_clbits; // -1 if not measured
+    int nClbits;
+    std::vector<std::vector<int>> measured_qubits_to_clbits; // empty if not measured
     std::string measure_outcome;
     double normalize_factor; // normalization factor used in measurement
     DdNode *bigBDD; // big BDD used if measurement
@@ -117,8 +117,7 @@ private:
         for (int i = 0; i < w; i++)
             delete[] All_Bdd[i];
         delete [] All_Bdd;
-        delete [] measured_qubits_to_clbits;
-        measured_qubits.clear();
+        measured_qubits_to_clbits.clear();
         measure_outcome.clear();
         Node_Table.clear();
         state_count.clear();

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -830,6 +830,13 @@ void Simulator::PauliX(int iqubit)
     {
         for (int j = 0; j < r; j++)
         {
+            /*
+            tmp = Cudd_bddCompose(manager,  All_Bdd[i][j], Cudd_Not(Cudd_bddIthVar(manager, iqubit)), iqubit);
+            Cudd_Ref(tmp);            
+            
+            Cudd_RecursiveDeref(manager, All_Bdd[i][j]);
+            All_Bdd[i][j] = tmp;*/
+            
             //term1
             term1 = Cudd_Cofactor(manager, All_Bdd[i][j], Cudd_Not(Cudd_bddIthVar(manager, iqubit)));
             Cudd_Ref(term1);
@@ -1066,6 +1073,6 @@ void Simulator::PauliZ(std::vector<int> iqubit)
 
 void Simulator::measure(int qreg, int creg)
 {
-    measured_qubits.push_back(qreg);
-    measured_qubits_to_clbits[qreg] = creg;
+    assert(creg < nClbits);
+    measured_qubits_to_clbits[qreg].push_back(creg);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,13 +12,9 @@ int main(int argc, char **argv)
     ("seed", po::value<unsigned int>()->implicit_value(1), "seed for random number generator")
     ("print_info", "print simulation statistics such as runtime, memory, etc.")
     ("type", po::value<unsigned int>()->default_value(0), "the simulation type being executed.\n" 
-                                                           "0: weak simulation (default option) where the sampled outcome(s) will be provided after the simulation. " 
-                                                           "The number of outcomes being sampled can be set by argument \"shots\" (1 by default).\n"
-                                                           "1: strong simulation where the resulting state vector will be shown after the simulation. "
-                                                           "Note that this option should be avoided if the number of qubits is large since it will result in extremely long runtime.")
-    ("shots", po::value<unsigned int>()->default_value(1), "the number of outcomes being sampled, " 
-                                                          "this argument is only used when the " 
-                                                          "simulation type is set to \"weak\".")
+                                                           "0: sampling mode (default option), where the sampled outcomes will be provided. \n"
+                                                           "1: all_amplitude mode, where the final state vector will be shown. ")
+    ("shots", po::value<unsigned int>()->default_value(1), "the number of outcomes being sampled in \"sampling mode\". " )
     ("r", po::value<unsigned int>()->default_value(32), "integer bit size.")
     ("reorder", po::value<bool>()->default_value(1), "allow variable reordering or not.\n"
                                                              "0: disable reordering.\n"
@@ -43,14 +39,7 @@ int main(int argc, char **argv)
 
     int type = vm["type"].as<unsigned int>(), shots = vm["shots"].as<unsigned int>(), r = vm["r"].as<unsigned int>();
     bool isReorder = vm["reorder"].as<bool>(), isAlloc = vm["alloc"].as<bool>();
-    if (type == 1)
-    {
-        shots = 1;
-    }
-    else
-    {
-        type = 0;
-    }
+
     std::random_device rd;
     unsigned int seed;
     if (vm.count("seed")) 


### PR DESCRIPTION
Rewrite README.md and --help message to clarify simulation types and matters needing attention;

add some warnings and error messages.
Adjust the measurement function to accommodate the following:
1. When only a subset of the qubits are measured, the padding 0's in the sampling outcomes will not be displayed.
2. A qubit can be measured multiple times in a single execution.